### PR TITLE
Rename middleware

### DIFF
--- a/docs/Policies.md
+++ b/docs/Policies.md
@@ -1,5 +1,5 @@
 # Policies
-Default controller using [Authentication](../src/Default/Middleware/AuthorizeAction.php) middleware that's authorizes API requests using [Laravel Authorization](https://laravel.com/docs/authorization).
+Default controller using the [Authorize](../src/Default/Middleware/Authorize.php) middleware that's authorizes API requests using [Laravel Authorization](https://laravel.com/docs/authorization).
 
 You can use `make:policy` Artisan command to generate a new policy class.
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -2,13 +2,13 @@
 
 namespace Sowl\JsonApi;
 
-use Sowl\JsonApi\Default\Middleware\AuthorizeAction;
+use Sowl\JsonApi\Default\Middleware\Authorize;
 
 class Controller extends \Illuminate\Routing\Controller
 {
     public function __construct()
     {
-        $this->middleware(AuthorizeAction::class)
+        $this->middleware(Authorize::class)
             ->except($this->noAuthMethods());
     }
 

--- a/src/Default/Middleware/Authorize.php
+++ b/src/Default/Middleware/Authorize.php
@@ -2,19 +2,17 @@
 
 namespace Sowl\JsonApi\Default\Middleware;
 
+use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Closure;
 use Sowl\JsonApi\Default\AbilitiesInterface;
 use Sowl\JsonApi\Exceptions\ForbiddenException;
 use Sowl\JsonApi\Exceptions\JsonApiException;
 use Sowl\JsonApi\Relationships\ToManyRelationship;
-use Sowl\JsonApi\Relationships\ToOneRelationship;
 use Sowl\JsonApi\Request;
 use Sowl\JsonApi\ResourceManager;
 
-use Illuminate\Http\Request as HttpRequest;
-use Illuminate\Contracts\Auth\Access\Gate;
-use Closure;
-
-class AuthorizeAction
+class Authorize
 {
     public function __construct(
         protected Gate            $gate,

--- a/src/Default/Middleware/Authorize.php
+++ b/src/Default/Middleware/Authorize.php
@@ -75,7 +75,7 @@ class Authorize
         }
 
         throw ForbiddenException::create()
-            ->error(403, [], sprintf('can\'t guest the ability for method "%s"', $method));
+            ->error(403, [], sprintf('Can\'t guess the ability for the method "%s"', $method));
     }
 
     /**

--- a/tests/laravel/app/Http/Kernel.php
+++ b/tests/laravel/app/Http/Kernel.php
@@ -3,7 +3,6 @@
 namespace Tests\App\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
-use Sowl\JsonApi\Default\Middleware\AuthorizeAction;
 
 class Kernel extends HttpKernel
 {


### PR DESCRIPTION
The name you choose (`AuthorizeAction`) for the middleware is somehow confusing since we already have "actions" in the `app/Http` sub-directories and the naming convention is `NameAction`.